### PR TITLE
feat: make "connect-history-api-fallback" support disabled.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,9 @@ export default function (api: IApi) {
         credentials: true,
       }),
       require('compression')(),
-      require('connect-history-api-fallback')({
-        index: '/',
-      }),
+      ...(api.config.mako.disableConnectHistoryApiFallback
+        ? []
+        : [require('connect-history-api-fallback')({ index: '/' })]),
       express.static(outputPath),
     ];
   });


### PR DESCRIPTION
在 umi3 中，貌似不引入 connect-history-api-fallback 中间件，也不会出现页面访问不到的情况？（本地项目直接去掉貌似一切正常）

反而引入之后会导致 https://github.com/umijs/umi-plugin-mako/issues/6 问题。可以让其支持禁用吗